### PR TITLE
Add landing animation to portfolio

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -23,7 +23,7 @@ export default [
     rules: {
       ...js.configs.recommended.rules,
       ...reactHooks.configs.recommended.rules,
-      'no-unused-vars': ['error', { varsIgnorePattern: '^[A-Z_]' }],
+      'no-unused-vars': ['error', { varsIgnorePattern: '^[A-Z_]|^motion$' }],
       'react-refresh/only-export-components': [
         'warn',
         { allowConstantExport: true },

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import Navbar from './components/Navbar';
 import Hero from './components/Hero';
 import About from './components/About';
@@ -7,23 +7,34 @@ import Projects from './components/Projects';
 import Experience from './components/Experience';
 import Contact from './components/Contact';
 import Footer from './components/Footer';
-import ScrollToTop from './components/ScrollToTop'; // Optional
+import ScrollToTop from './components/ScrollToTop';
+import LandingAnimation from './components/LandingAnimation';
+import { AnimatePresence } from 'framer-motion';
 
 function App() {
+  const [showAnimation, setShowAnimation] = useState(true);
+
   return (
-    <div className="App">
-      <Navbar />
-      <main>
-        <Hero />
-        <About />
-        <Skills />
-        <Projects />
-        <Experience />
-        <Contact />
-      </main>
-      {/* <Footer /> */}
-      <ScrollToTop /> {/* Optional */}
-    </div>
+    <>
+      <AnimatePresence>
+        {showAnimation && (
+          <LandingAnimation onComplete={() => setShowAnimation(false)} />
+        )}
+      </AnimatePresence>
+      <div className="App">
+        <Navbar />
+        <main>
+          <Hero />
+          <About />
+          <Skills />
+          <Projects />
+          <Experience />
+          <Contact />
+        </main>
+        <Footer />
+        <ScrollToTop />
+      </div>
+    </>
   );
 }
 

--- a/src/components/About.jsx
+++ b/src/components/About.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import SectionTitle from './SectionTitle';
-import { personalInfo, education } from '../data/portfolioData.jsx';
+import { education } from '../data/portfolioData.jsx';
 import { motion } from 'framer-motion';
 import { FaUniversity, FaSchool } from 'react-icons/fa'; // Example icons
 

--- a/src/components/LandingAnimation.jsx
+++ b/src/components/LandingAnimation.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+import { personalInfo } from '../data/portfolioData.jsx';
+
+const LandingAnimation = ({ onComplete }) => (
+  <motion.div
+    className="fixed inset-0 flex items-center justify-center bg-primary-bg z-50"
+    initial={{ opacity: 1 }}
+    animate={{ opacity: 0 }}
+    transition={{ duration: 1.2, ease: 'easeOut', delay: 0.5 }}
+    onAnimationComplete={onComplete}
+  >
+    <motion.h1
+      className="text-4xl sm:text-6xl font-bold text-accent-1"
+      initial={{ scale: 0.8 }}
+      animate={{ scale: 1 }}
+      transition={{ duration: 0.8, ease: 'easeOut' }}
+    >
+      {personalInfo.name}
+    </motion.h1>
+  </motion.div>
+);
+
+export default LandingAnimation;

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Link as ScrollLink } from 'react-scroll';
-import { personalInfo, socialLinks } from '../data/portfolioData.jsx';
+import { personalInfo } from '../data/portfolioData.jsx';
 import { FaBars, FaTimes } from 'react-icons/fa';
 import { motion } from 'framer-motion';
 


### PR DESCRIPTION
## Summary
- hide landing overlay when the fade-out completes using AnimatePresence
- restore footer and simplify scroll-to-top setup
- adjust ESLint rule to ignore the framer-motion helper precisely

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895990c29b4832fba7cf577f4402960